### PR TITLE
Allow react 18.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "peerDependencies": {
     "next": ">=10.0.0",
-    "react": "16.x || 17.x",
-    "react-dom": "16.x || 17.x"
+    "react": "16.x || 17.x || 18.x",
+    "react-dom": "16.x || 17.x || 18.x"
   },
   "dependencies": {
     "cookie": "^0.4.1",


### PR DESCRIPTION
[Next.js supports React 18](https://nextjs.org/docs/advanced-features/react-18/overview), but this package.json currently prevents this.

Thank you for this package!